### PR TITLE
Add IE support for Math.trunc

### DIFF
--- a/Resources/js/helpers.js
+++ b/Resources/js/helpers.js
@@ -42,3 +42,15 @@ export function validateEmail(address) {
     var regex = RegExp("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?");
     return regex.test(address);
 }
+
+// Polyfill to support Internet Explorer
+// (doesn't support Math.trunc by default)
+Math.trunc = Math.trunc || function (x) {
+    if (isNaN(x)) {
+        return NaN;
+    }
+    if (x > 0) {
+        return Math.floor(x);
+    }
+    return Math.ceil(x);
+};


### PR DESCRIPTION
Currently the site fails to display on Internet Explorer, because the browser doesn't support Math.trunc().

This PR adds code that defines the function if a browser doesn't already have a definition. Tested by opening main page on Chrome, Edge and IE. All browsers functioning with no console errors.

Ref: https://stackoverflow.com/questions/44576098/the-object-doesnt-accept-property-or-method/44576137

