### PR TITLE
Improve media component

### DIFF
--- a/Resources/js/React/CMS-Blocks/Media.js
+++ b/Resources/js/React/CMS-Blocks/Media.js
@@ -17,11 +17,13 @@ export default class Media extends Component {
                 filename: "",
                 alt: ""
             }, 
+            ImageAspect: null,
             Height: 1,
             Width: 1,
             showModal: false
         }
 
+        this.onImageLoad = this.onImageLoad.bind(this);
         this.contentRef = React.createRef();
     }
 
@@ -35,6 +37,13 @@ export default class Media extends Component {
         this.setState({
             default: _.cloneDeep(nextProps.content),
             content: _.cloneDeep(nextProps.content)
+        });
+    }
+
+    // Determine the dimensions of the original image from the server
+    onImageLoad({target:img}) {
+        this.setState({
+            ImageAspect: img.naturalHeight / img.naturalWidth
         });
     }
 
@@ -134,7 +143,8 @@ export default class Media extends Component {
 
         // If we are not in edit mode, and no image exists then hide the image.
         let image = !this.props.allowEdits && !this.state.content.filename ? null : (
-            <img src={this.ImageUrl()}
+            <img onLoad={this.onImageLoad}
+                src={this.ImageUrl()}
                 alt={this.state.content ? this.state.content.alt : ""}
                 style={{
                     'position': 'absolute',
@@ -147,8 +157,10 @@ export default class Media extends Component {
             />
         )
 
+        let calculatedHeight = this.state.ImageAspect != null ? this.state.ImageAspect * this.state.Width : null;
+
         return (
-            <div style={{ 'position': 'relative', 'minHeight': this.props.minSize || '250px' }} ref={this.contentRef} >
+            <div style={{ 'position': 'relative', 'minHeight': calculatedHeight || this.props.minHeight }} ref={this.contentRef} >
                 {image}
                 {selectFile}
             </div>

--- a/Resources/js/React/CMS-Blocks/SelectMedia.js
+++ b/Resources/js/React/CMS-Blocks/SelectMedia.js
@@ -60,7 +60,7 @@ export default class SelectMedia extends Component {
             if (!this.Filter(media)) return null;
 
             return (
-                <div className="col-md-4 col-sm-6" key={key}>
+                <div className="col-lg-4 col-6" key={key}>
                     <Item file={media} selected={media.id == this.state.selectedId} cb={(selectedId) => this.setState({ selectedId })}/>
                 </div>
             )
@@ -95,7 +95,8 @@ class Item extends Component {
         return (
             <div className={this.props.selected ? "selected" : null}>
                 <img src={`/media?filename=${this.props.file.filename}`}
-                    style={{ 'width': '100%' }}
+                    style={{ 'width': '100%', 'objectFit': 'cover' }}
+                    height={'200px'}
                     alt={this.props.file.name}
                     onClick={this.props.cb.bind(this, this.props.file.id)}
                 />

--- a/Resources/js/React/PageTemplates/10.js
+++ b/Resources/js/React/PageTemplates/10.js
@@ -37,7 +37,7 @@ export default class ReactTemplate10 extends Component {
 
 
                 <div className="row pt-4">
-                    <div className="col-lg-4 col-md-2 col-sm-12 mb-4">
+                    <div className="col-lg-4 col-md-6 col-sm-12 mb-4">
                         <div style={{ 'margin': '-1rem 0rem 2rem 0rem' }}>
                             <Media minHeight="200"
                                 allowEdits={this.props.allowEdits}
@@ -53,7 +53,7 @@ export default class ReactTemplate10 extends Component {
                         />
                     </div>
 
-                    <div className="col-lg-4 col-md-2 col-sm-12 mb-4">
+                    <div className="col-lg-4 col-md-6 col-sm-12 mb-4">
                         <div style={{ 'margin': '-1rem 0rem 2rem 0rem' }}>
                             <Media minHeight="200"
                                 allowEdits={this.props.allowEdits}
@@ -69,7 +69,7 @@ export default class ReactTemplate10 extends Component {
                         />
                     </div>
 
-                    <div className="col-lg-4 col-md-2 col-sm-12 mb-4">
+                    <div className="col-lg-4 col-md-6 col-sm-12 mb-4">
                         <div style={{ 'margin': '-1rem 0rem 2rem 0rem' }}>
                             <Media minHeight="200"
                                 allowEdits={this.props.allowEdits}
@@ -85,7 +85,7 @@ export default class ReactTemplate10 extends Component {
                         />
                     </div>
 
-                    <div className="col-lg-4 col-md-2 col-sm-12 mb-4">
+                    <div className="col-lg-4 col-md-6 col-sm-12 mb-4">
                         <div style={{ 'margin': '-1rem 0rem 2rem 0rem' }}>
                             <Media minHeight="200"
                                 allowEdits={this.props.allowEdits}
@@ -101,7 +101,7 @@ export default class ReactTemplate10 extends Component {
                         />
                     </div>
 
-                    <div className="col-lg-4 col-md-2 col-sm-12 mb-4">
+                    <div className="col-lg-4 col-md-6 col-sm-12 mb-4">
                         <div style={{ 'margin': '-1rem 0rem 2rem 0rem' }}>
                             <Media minHeight="200"
                                 allowEdits={this.props.allowEdits}
@@ -117,7 +117,7 @@ export default class ReactTemplate10 extends Component {
                         />
                     </div>
 
-                    <div className="col-lg-4 col-md-2 col-sm-12 mb-4">
+                    <div className="col-lg-4 col-md-6 col-sm-12 mb-4">
                         <div style={{ 'margin': '-1rem 0rem 2rem 0rem' }}>
                             <Media minHeight="200"
                                 allowEdits={this.props.allowEdits}


### PR DESCRIPTION
Images now display without cropping.

Still leaves room for improvement:
- User now has to make sure that they crop images to the correct heights to avoid content being misaligned on the page
- Image select modal is all out of alignment

Potential fix would be to add a 'forceHeight' property to the media component, and make it optional. This could be used to align the select modal images, as they can be cropped here with no problems.

Could also think about adding the option for the user to select how they want the image to display:
- A) they provide a fixed height and the image will crop/clip (what the site currently does, except we set height rather than the user)
- B) they provide a fixed height and the image will be contained (i.e largest image size without cropping - the image might not fill the containing div
- C) the image height is dynamically changed to fit the image (what this PR is doing)

