### PR TITLE
Implement app media sync

### DIFF
--- a/DiscoverDeepCove/Controllers/MediaController.cs
+++ b/DiscoverDeepCove/Controllers/MediaController.cs
@@ -28,7 +28,7 @@ namespace Deepcove_Trust_Website.DiscoverDeepCove.Controllers
         /// Returns a list of media files used in the mobile application
         /// </summary>
         /// <returns></returns>
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(int width)
         {
             try
             {
@@ -54,7 +54,7 @@ namespace Deepcove_Trust_Website.DiscoverDeepCove.Controllers
                 return Ok(_Db.Media.Where(c => appMediaIds.Contains(c.Id)).Select(s => new
                     {
                         s.Id,
-                        s.Size,
+                        Size = s.GetFileSize(width),
                         s.Filename,
                         UpdatedAt = s.UpdatedAt.ToString("yyyy-MM-dd HH:mm:ss")
                     }).ToList()
@@ -72,7 +72,7 @@ namespace Deepcove_Trust_Website.DiscoverDeepCove.Controllers
         /// Gets the meta data about the requested media.
         /// </summary>
         [HttpGet("{id:int}")]
-        public IActionResult Data(int id)
+        public IActionResult Data(int id, int width)
         {
             try
             {
@@ -82,8 +82,8 @@ namespace Deepcove_Trust_Website.DiscoverDeepCove.Controllers
                         s.MediaType.Category,
                         Name = (s as ImageMedia) != null ? (s as ImageMedia).Title : s.Filename,
                         s.Source,
-                        show_copyright = s.ShowCopyright, 
-                        s.Size,
+                        show_copyright = s.ShowCopyright,
+                        Size = s.GetFileSize(width),
                         s.Filename,
                         updated_at = s.UpdatedAt.ToString("yyyy-MM-dd HH:mm:ss")
                 }).FirstOrDefault()

--- a/DiscoverDeepCove/Controllers/MediaController.cs
+++ b/DiscoverDeepCove/Controllers/MediaController.cs
@@ -35,19 +35,19 @@ namespace Deepcove_Trust_Website.DiscoverDeepCove.Controllers
                 List<int?> appMediaIds = new List<int?>();
 
                 // Add all image IDs used within the application
-                appMediaIds.AddRange(await _Db.Activities.Where(w => w.Active && w.Track.Active).Select(s => s.ImageId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.ActivityImages.Where(w => w.Activity.Active && w.Activity.Track.Active).Select(s => (int?)s.ImageId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.FactFileEntries.Where(w => w.Active && w.Category.Active).Select(s => (int?)s.MainImageId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.FactFileEntryImages.Where(w => w.FactFileEntry.Active && w.FactFileEntry.Category.Active).Select(s => (int?)s.MediaFileId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.FactFileNuggets.Where(w => w.FactFileEntry.Active && w.FactFileEntry.Category.Active).Select(s => s.ImageId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.QuizAnswers.Where(w => w.QuizQuestion.Quiz.Active).Select(s => s.ImageId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.QuizQuestions.Where(w => w.Quiz.Active).Select(s => s.ImageId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.Quizzes.Where(w => w.Active).Select(s => (int?)s.ImageId).Distinct().ToListAsync());
+                appMediaIds.AddRange(await _Db.Activities.Where(w => w.Active && w.Track.Active).Select(s => s.ImageId).ToListAsync());
+                appMediaIds.AddRange(await _Db.ActivityImages.Where(w => w.Activity.Active && w.Activity.Track.Active).Select(s => (int?)s.ImageId).ToListAsync());
+                appMediaIds.AddRange(await _Db.FactFileEntries.Where(w => w.Active && w.Category.Active).Select(s => (int?)s.MainImageId).ToListAsync());
+                appMediaIds.AddRange(await _Db.FactFileEntryImages.Where(w => w.FactFileEntry.Active && w.FactFileEntry.Category.Active).Select(s => (int?)s.MediaFileId).ToListAsync());
+                appMediaIds.AddRange(await _Db.FactFileNuggets.Where(w => w.FactFileEntry.Active && w.FactFileEntry.Category.Active).Select(s => s.ImageId).ToListAsync());
+                appMediaIds.AddRange(await _Db.QuizAnswers.Where(w => w.QuizQuestion.Quiz.Active).Select(s => s.ImageId).ToListAsync());
+                appMediaIds.AddRange(await _Db.QuizQuestions.Where(w => w.Quiz.Active).Select(s => s.ImageId).ToListAsync());
+                appMediaIds.AddRange(await _Db.Quizzes.Where(w => w.Active).Select(s => (int?)s.ImageId).ToListAsync());
 
                 // Add all audio IDs used within the application
-                appMediaIds.AddRange(await _Db.FactFileEntries.Where(w => w.Active && w.Category.Active).Select(s => s.ListenAudioId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.FactFileEntries.Where(w => w.Active && w.Category.Active).Select(s => s.PronounceAudioId).Distinct().ToListAsync());
-                appMediaIds.AddRange(await _Db.QuizQuestions.Where(w => w.Quiz.Active).Select(s => s.AudioId).Distinct().ToListAsync());
+                appMediaIds.AddRange(await _Db.FactFileEntries.Where(w => w.Active && w.Category.Active).Select(s => s.ListenAudioId).ToListAsync());
+                appMediaIds.AddRange(await _Db.FactFileEntries.Where(w => w.Active && w.Category.Active).Select(s => s.PronounceAudioId).ToListAsync());
+                appMediaIds.AddRange(await _Db.QuizQuestions.Where(w => w.Quiz.Active).Select(s => s.AudioId).ToListAsync());
 
                 appMediaIds = appMediaIds.Distinct().ToList();
                 

--- a/Models/BaseMedia.cs
+++ b/Models/BaseMedia.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -78,6 +79,17 @@ namespace Deepcove_Trust_Website.Models
         }
 
         public MediaCategory GetCategory() => MediaType.Category;
+
+        public long GetFileSize(int imageWidth = 0)
+        {
+            // If not an image, return the uploaded file size
+            if (MediaType.Category != MediaCategory.Image)
+                return Size;
+
+            // Otherwise, return size of appropriate version
+            string bestImagePath = ((ImageMedia)this).GetImagePath(imageWidth);
+            return new FileInfo(bestImagePath).Length;
+        }
 
         public Dictionary<String, HashSet<int>> GetUsages(WebsiteDataContext db)
         {


### PR DESCRIPTION
Currently the api/app/media endpoint tells the mobile app to download *all* media files whose `isPublic` field is true. 

This PR changes this so that the endpoint will tell the app only to download media files that are used in the app.

Putting this logic into the BaseMedia model is a better way of doing it, but brings about some issues with EF Core that I think are more hassle than they are worth, for the moment. Some kind of solution will be needed when we prevent users from deleting media files that are in use.

Update: Latest commit also allows the API to return the sizes of the scaled images to the mobile application, improving the accuracy of the download size indication. 