### PR TITLE
Switch to NReco package for audio duration

### DIFF
--- a/Controllers/AdminPortal/ManageMediaController.cs
+++ b/Controllers/AdminPortal/ManageMediaController.cs
@@ -14,7 +14,6 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using NReco.VideoInfo;
 using Microsoft.AspNetCore.Hosting;
-using System.Runtime.InteropServices;
 using Microsoft.Extensions.Configuration;
 
 namespace Deepcove_Trust_Website.Controllers.AdminPortal

--- a/Controllers/AdminPortal/ManageMediaController.cs
+++ b/Controllers/AdminPortal/ManageMediaController.cs
@@ -164,7 +164,7 @@ namespace Deepcove_Trust_Website.Controllers.AdminPortal
                     // Read the audio file to determine its duration - it will either be mp3(mpeg) or wav
 
                     FFProbe probe = new FFProbe();
-                    probe.ToolPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? _Config["ffprobePath:Windows"] : _Config["ffprobePath:Linux"];
+                    probe.ToolPath = _Config["ffprobePath"];
                     MediaInfo mediaInfo = probe.GetMediaInfo(Path.Combine(_HostingEnv.ContentRootPath, filepath));
 
                     // Create the media database record

--- a/Controllers/AdminPortal/ManageMediaController.cs
+++ b/Controllers/AdminPortal/ManageMediaController.cs
@@ -12,7 +12,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using NAudio.Wave;
+using NReco.VideoInfo;
+using Microsoft.AspNetCore.Hosting;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Configuration;
 
 namespace Deepcove_Trust_Website.Controllers.AdminPortal
 {
@@ -23,11 +26,15 @@ namespace Deepcove_Trust_Website.Controllers.AdminPortal
     {
         private WebsiteDataContext _Db;
         private ILogger<ManageMediaController> _Logger;
+        private IHostingEnvironment _HostingEnv;
+        private IConfiguration _Config;
 
-        public ManageMediaController(WebsiteDataContext Db, ILogger<ManageMediaController> Logger)
+        public ManageMediaController(WebsiteDataContext Db, ILogger<ManageMediaController> Logger, IHostingEnvironment HostingEnv, IConfiguration Config)
         {
             _Db = Db;
-            _Logger = Logger;            
+            _Logger = Logger;
+            _HostingEnv = HostingEnv;
+            _Config = Config;
         }
 
         [HttpGet]
@@ -152,16 +159,13 @@ namespace Deepcove_Trust_Website.Controllers.AdminPortal
 
                     // Save the audio file
                     byte[] bytes = request.Str("file").Split(',')[1].DecodeBase64Bytes();
-                    System.IO.File.WriteAllBytes(filepath, bytes);
+                    await System.IO.File.WriteAllBytesAsync(filepath, bytes);
 
                     // Read the audio file to determine its duration - it will either be mp3(mpeg) or wav
 
-                    WaveStream audioReader;
-
-                    if (fileType == MediaType.Wav.Mime)
-                        audioReader = new WaveFileReader(filepath);                    
-                    else                    
-                        audioReader = new Mp3FileReader(filepath);
+                    FFProbe probe = new FFProbe();
+                    probe.ToolPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? _Config["ffprobePath:Windows"] : _Config["ffprobePath:Linux"];
+                    MediaInfo mediaInfo = probe.GetMediaInfo(Path.Combine(_HostingEnv.ContentRootPath, filepath));
 
                     // Create the media database record
                     AudioMedia audioMedia = new AudioMedia
@@ -170,9 +174,9 @@ namespace Deepcove_Trust_Website.Controllers.AdminPortal
                         MediaType = MediaType.FromString(fileType),
                         FilePath = filepath,
                         Size = new FileInfo(filepath).Length,
-                        Duration = Math.Round(audioReader.TotalTime.TotalSeconds)
+                        Duration = Math.Round(mediaInfo.Duration.TotalSeconds)
                     };
-
+                    
                     await _Db.AddAsync(audioMedia);
                 }
 

--- a/Deepcove-Trust-Website.csproj
+++ b/Deepcove-Trust-Website.csproj
@@ -149,8 +149,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
-    <PackageReference Include="NAudio" Version="1.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="NReco.VideoInfo.LT" Version="1.1.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.2.0" />
     <PackageReference Include="reCAPTCHA.AspNetCore" Version="2.2.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />


### PR DESCRIPTION
NAudio was being used to collect audio file duration, but was not cross-platform. 

It has been replaced with NReco.VideoInfo.LT, which is capable of this function. It relies upon the ffprobe.exe program that comes with ffmpeg.

See the [wiki page](https://github.com/ssm-deepcove/deepcove-website/wiki/Installing-ffmpeg---ffprobe) for installation assistance, as some appsettings values need to be added to make this work.